### PR TITLE
Feature/processor api

### DIFF
--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
@@ -47,7 +47,9 @@ public class AxonHubConfiguration {
     private int commandThreads = 10;
     private int queryThreads = 10;
 
-    private int processorsNotificationPeriod = 5;
+    private int processorsNotificationRate = 5000;
+
+    private int processorsNotificationInitialDelay = 5000;
 
     private EventCipher eventCipher = new EventCipher();
 
@@ -178,12 +180,20 @@ public class AxonHubConfiguration {
         this.queryThreads = queryThreads;
     }
 
-    public int getProcessorsNotificationPeriod() {
-        return processorsNotificationPeriod;
+    public int getProcessorsNotificationRate() {
+        return processorsNotificationRate;
     }
 
-    public void setProcessorsNotificationPeriod(int processorsNotificationPeriod) {
-        this.processorsNotificationPeriod = processorsNotificationPeriod;
+    public void setProcessorsNotificationRate(int processorsNotificationRate) {
+        this.processorsNotificationRate = processorsNotificationRate;
+    }
+
+    public int getProcessorsNotificationInitialDelay() {
+        return processorsNotificationInitialDelay;
+    }
+
+    public void setProcessorsNotificationInitialDelay(int processorsNotificationInitialDelay) {
+        this.processorsNotificationInitialDelay = processorsNotificationInitialDelay;
     }
 
     @SuppressWarnings("unused")

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
@@ -47,6 +47,8 @@ public class AxonHubConfiguration {
     private int commandThreads = 10;
     private int queryThreads = 10;
 
+    private int processorsNotificationPeriod = 5;
+
     private EventCipher eventCipher = new EventCipher();
 
 
@@ -174,6 +176,14 @@ public class AxonHubConfiguration {
 
     public void setQueryThreads(int queryThreads) {
         this.queryThreads = queryThreads;
+    }
+
+    public int getProcessorsNotificationPeriod() {
+        return processorsNotificationPeriod;
+    }
+
+    public void setProcessorsNotificationPeriod(int processorsNotificationPeriod) {
+        this.processorsNotificationPeriod = processorsNotificationPeriod;
     }
 
     @SuppressWarnings("unused")

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/PlatformConnectionManager.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/PlatformConnectionManager.java
@@ -17,9 +17,24 @@ package io.axoniq.axonhub.client;
 
 import io.axoniq.axonhub.client.util.ContextAddingInterceptor;
 import io.axoniq.axonhub.client.util.TokenAddingInterceptor;
-import io.axoniq.axonhub.grpc.*;
-import io.axoniq.platform.grpc.*;
-import io.grpc.*;
+import io.axoniq.axonhub.grpc.CommandProviderInbound;
+import io.axoniq.axonhub.grpc.CommandProviderOutbound;
+import io.axoniq.axonhub.grpc.CommandServiceGrpc;
+import io.axoniq.axonhub.grpc.QueryProviderInbound;
+import io.axoniq.axonhub.grpc.QueryProviderOutbound;
+import io.axoniq.axonhub.grpc.QueryServiceGrpc;
+import io.axoniq.platform.grpc.ClientIdentification;
+import io.axoniq.platform.grpc.NodeInfo;
+import io.axoniq.platform.grpc.PlatformInboundInstruction;
+import io.axoniq.platform.grpc.PlatformInfo;
+import io.axoniq.platform.grpc.PlatformOutboundInstruction;
+import io.axoniq.platform.grpc.PlatformServiceGrpc;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -27,15 +42,20 @@ import io.netty.handler.ssl.SslContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLException;
 import java.io.File;
 import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.Collection;
 import java.util.EnumMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.net.ssl.SSLException;
 
 /**
  * @author Marc Gathier
@@ -50,6 +70,7 @@ public class PlatformConnectionManager {
     private final List<Runnable> disconnectListeners = new CopyOnWriteArrayList<>();
     private final List<Runnable> reconnectListeners = new CopyOnWriteArrayList<>();
     private final AxonHubConfiguration connectInformation;
+    private final Map<PlatformOutboundInstruction.RequestCase, Collection<Consumer<PlatformOutboundInstruction>>> handlers = new EnumMap<>(PlatformOutboundInstruction.RequestCase.class);
 
     public PlatformConnectionManager(AxonHubConfiguration connectInformation) {
         this.connectInformation = connectInformation;
@@ -139,8 +160,6 @@ public class PlatformConnectionManager {
                                 inputStream.onCompleted();
                                 scheduleReconnect();
                                 break;
-                            case REQUEST_RELEASE_TRACKER:
-                                break;
                             case REQUEST_NOT_SET:
                                 break;
                         }
@@ -207,10 +226,8 @@ public class PlatformConnectionManager {
                 .openStream(queryProviderInboundStreamObserver);
     }
 
-    private final Map<PlatformOutboundInstruction.RequestCase, Deque<Consumer<PlatformOutboundInstruction>>> handlers = new EnumMap<>(PlatformOutboundInstruction.RequestCase.class);
-
     public void onOutboundInstruction(PlatformOutboundInstruction.RequestCase requestCase, Consumer<PlatformOutboundInstruction> consumer){
-        Deque<Consumer<PlatformOutboundInstruction>> consumers = this.handlers.computeIfAbsent(requestCase, (rc) -> new ArrayDeque<>());
+        Collection<Consumer<PlatformOutboundInstruction>> consumers = this.handlers.computeIfAbsent(requestCase, (rc) -> new LinkedList<>());
         consumers.add(consumer);
     }
 

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/EventProcessorControlService.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/EventProcessorControlService.java
@@ -1,0 +1,66 @@
+package io.axoniq.axonhub.client.event;
+
+import io.axoniq.axonhub.client.PlatformConnectionManager;
+import io.axoniq.axonhub.client.event.axon.EventProcessorController;
+import io.axoniq.platform.grpc.EventProcessorPaused;
+import io.axoniq.platform.grpc.EventProcessorStarted;
+import io.axoniq.platform.grpc.PauseEventProcessor;
+import io.axoniq.platform.grpc.PlatformInboundInstruction;
+import io.axoniq.platform.grpc.PlatformOutboundInstruction;
+import io.axoniq.platform.grpc.StartEventProcessor;
+
+import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.PAUSE_EVENT_PROCESSOR;
+import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.STAR_EVENT_PROCESSOR;
+
+/**
+ * Created by Sara Pellegrini on 09/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class EventProcessorControlService {
+
+    private final PlatformConnectionManager platformConnectionManager;
+
+    private final EventProcessorController eventProcessorController;
+
+    public EventProcessorControlService(PlatformConnectionManager platformConnectionManager,
+                                        EventProcessorController eventProcessorController) {
+        this.platformConnectionManager = platformConnectionManager;
+        this.eventProcessorController = eventProcessorController;
+
+        this.platformConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
+        this.platformConnectionManager.onOutboundInstruction(STAR_EVENT_PROCESSOR, this::startProcessor);
+
+        this.eventProcessorController.onPause(this::notifyProcessorPaused);
+        this.eventProcessorController.onStart(this::notifyProcessorStarted);
+    }
+
+    public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction){
+        PauseEventProcessor pauseEventProcessor = platformOutboundInstruction.getPauseEventProcessor();
+        String processorName = pauseEventProcessor.getProcessorName();
+        eventProcessorController.pauseProcessor(processorName);
+    }
+
+    public void startProcessor(PlatformOutboundInstruction platformOutboundInstruction){
+        StartEventProcessor starEventProcessor = platformOutboundInstruction.getStarEventProcessor();
+        String processorName = starEventProcessor.getProcessorName();
+        eventProcessorController.startProcessor(processorName);
+    }
+
+    public void notifyProcessorStarted(String processorName){
+        EventProcessorStarted.Builder message = EventProcessorStarted.newBuilder().setProcessorName(processorName);
+        PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
+                                                                           .setEventProcessorStarted(message)
+                                                                           .build();
+        platformConnectionManager.send(instruction);
+    }
+
+    public void notifyProcessorPaused(String processorName){
+        EventProcessorPaused.Builder message = EventProcessorPaused.newBuilder().setProcessorName(processorName);
+        PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
+                                                                           .setEventProcessorPaused(message)
+                                                                           .build();
+        platformConnectionManager.send(instruction);
+    }
+
+
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/AxonHubEvenProcessorInfoConfiguration.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/AxonHubEvenProcessorInfoConfiguration.java
@@ -1,0 +1,52 @@
+package io.axoniq.axonhub.client.event.axon;
+
+import io.axoniq.axonhub.client.AxonHubConfiguration;
+import io.axoniq.axonhub.client.PlatformConnectionManager;
+import io.axoniq.axonhub.client.processor.EventProcessorControlService;
+import io.axoniq.axonhub.client.processor.EventProcessorController;
+import io.axoniq.axonhub.client.processor.grpc.GrpcEventProcessorInfoSource;
+import io.axoniq.axonhub.client.processor.schedule.ScheduledEventProcessorInfoSource;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.EventHandlingConfiguration;
+import org.axonframework.config.ModuleConfiguration;
+
+/**
+ * Created by Sara Pellegrini on 03/04/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class AxonHubEvenProcessorInfoConfiguration implements ModuleConfiguration {
+
+    private final EventProcessorControlService eventProcessorControlService;
+
+    private final ScheduledEventProcessorInfoSource processorInfoSource;
+
+    public AxonHubEvenProcessorInfoConfiguration(
+            EventHandlingConfiguration eventHandlingConfiguration,
+            PlatformConnectionManager connectionManager,
+            AxonHubConfiguration configuration) {
+        EventProcessorController processorController = new EventProcessorController(eventHandlingConfiguration);
+        this.eventProcessorControlService = new EventProcessorControlService(connectionManager, processorController);
+
+        GrpcEventProcessorInfoSource delegate = new GrpcEventProcessorInfoSource(
+                eventHandlingConfiguration,
+                connectionManager);
+        this.processorInfoSource = new ScheduledEventProcessorInfoSource(
+                configuration.getProcessorsNotificationInitialDelay(),
+                configuration.getProcessorsNotificationRate(),
+                delegate);
+    }
+
+    @Override
+    public void initialize(Configuration config) {
+    }
+
+    @Override
+    public void start() {
+        processorInfoSource.start();
+        eventProcessorControlService.init();
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/AxonHubEvenProcessorInfoConfiguration.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/AxonHubEvenProcessorInfoConfiguration.java
@@ -43,10 +43,11 @@ public class AxonHubEvenProcessorInfoConfiguration implements ModuleConfiguratio
     @Override
     public void start() {
         processorInfoSource.start();
-        eventProcessorControlService.init();
+        eventProcessorControlService.start();
     }
 
     @Override
     public void shutdown() {
+        processorInfoSource.shutdown();
     }
 }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/EventProcessorController.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/event/axon/EventProcessorController.java
@@ -1,0 +1,50 @@
+package io.axoniq.axonhub.client.event.axon;
+
+import org.axonframework.config.EventHandlingConfiguration;
+import org.axonframework.eventhandling.EventProcessor;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Consumer;
+
+/**
+ * Created by Sara Pellegrini on 09/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class EventProcessorController {
+
+    private final EventHandlingConfiguration eventHandlingConfiguration;
+
+    private final Deque<Consumer<String>> pauseHandlers = new ArrayDeque<>();
+
+    private final Deque<Consumer<String>> startHandlers = new ArrayDeque<>();
+
+    public EventProcessorController(EventHandlingConfiguration eventHandlingConfiguration) {
+        this.eventHandlingConfiguration = eventHandlingConfiguration;
+    }
+
+    private EventProcessor getEventProcessor(String processorName){
+        return this.eventHandlingConfiguration
+                .getProcessor(processorName)
+                .orElseThrow(() -> new RuntimeException("Processor not found"));
+    }
+
+    public void pauseProcessor(String processor){
+        //TODO check if it is intended only for tracking processor (pause method instead of shutDown)
+        getEventProcessor(processor).shutDown();
+        this.pauseHandlers.forEach(consumer -> consumer.accept(processor));
+    }
+
+    public void startProcessor(String processor){
+        getEventProcessor(processor).start();
+        this.startHandlers.forEach(consumer -> consumer.accept(processor));
+    }
+
+    public void onPause(Consumer<String> consumer){
+        this.pauseHandlers.add(consumer);
+    }
+
+    public void onStart(Consumer<String> consumer){
+        this.startHandlers.add(consumer);
+    }
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/AxonHubEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/AxonHubEventProcessorInfoSource.java
@@ -7,19 +7,4 @@ package io.axoniq.axonhub.client.processor;
 public interface AxonHubEventProcessorInfoSource {
 
     void notifyInformation();
-
-    class Fake implements AxonHubEventProcessorInfoSource {
-
-        private int notifyCalls;
-
-        @Override
-        public void notifyInformation() {
-            notifyCalls++;
-        }
-
-        public int notifyCalls() {
-            return notifyCalls;
-        }
-    }
-
 }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/AxonHubEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/AxonHubEventProcessorInfoSource.java
@@ -1,0 +1,25 @@
+package io.axoniq.axonhub.client.processor;
+
+/**
+ * Created by Sara Pellegrini on 09/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public interface AxonHubEventProcessorInfoSource {
+
+    void notifyInformation();
+
+    class Fake implements AxonHubEventProcessorInfoSource {
+
+        private int notifyCalls;
+
+        @Override
+        public void notifyInformation() {
+            notifyCalls++;
+        }
+
+        public int notifyCalls() {
+            return notifyCalls;
+        }
+    }
+
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
@@ -6,7 +6,7 @@ import io.axoniq.platform.grpc.PlatformOutboundInstruction;
 import io.axoniq.platform.grpc.StartEventProcessor;
 
 import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.PAUSE_EVENT_PROCESSOR;
-import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.STAR_EVENT_PROCESSOR;
+import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.START_EVENT_PROCESSOR;
 
 
 
@@ -28,7 +28,7 @@ public class EventProcessorControlService {
 
     public void init(){
         this.platformConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
-        this.platformConnectionManager.onOutboundInstruction(STAR_EVENT_PROCESSOR, this::startProcessor);
+        this.platformConnectionManager.onOutboundInstruction(START_EVENT_PROCESSOR, this::startProcessor);
     }
 
     public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
@@ -38,8 +38,8 @@ public class EventProcessorControlService {
     }
 
     public void startProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
-        StartEventProcessor starEventProcessor = platformOutboundInstruction.getStarEventProcessor();
-        String processorName = starEventProcessor.getProcessorName();
+        StartEventProcessor startEventProcessor = platformOutboundInstruction.getStartEventProcessor();
+        String processorName = startEventProcessor.getProcessorName();
         eventProcessorController.startProcessor(processorName);
     }
 

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
@@ -1,15 +1,14 @@
 package io.axoniq.axonhub.client.processor;
 
 import io.axoniq.axonhub.client.PlatformConnectionManager;
-import io.axoniq.platform.grpc.EventProcessorPaused;
-import io.axoniq.platform.grpc.EventProcessorStarted;
 import io.axoniq.platform.grpc.PauseEventProcessor;
-import io.axoniq.platform.grpc.PlatformInboundInstruction;
 import io.axoniq.platform.grpc.PlatformOutboundInstruction;
 import io.axoniq.platform.grpc.StartEventProcessor;
 
 import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.PAUSE_EVENT_PROCESSOR;
 import static io.axoniq.platform.grpc.PlatformOutboundInstruction.RequestCase.STAR_EVENT_PROCESSOR;
+
+
 
 /**
  * Created by Sara Pellegrini on 09/03/2018.
@@ -30,9 +29,6 @@ public class EventProcessorControlService {
     public void init(){
         this.platformConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
         this.platformConnectionManager.onOutboundInstruction(STAR_EVENT_PROCESSOR, this::startProcessor);
-
-        this.eventProcessorController.onPause(this::notifyProcessorPaused);
-        this.eventProcessorController.onStart(this::notifyProcessorStarted);
     }
 
     public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
@@ -47,21 +43,7 @@ public class EventProcessorControlService {
         eventProcessorController.startProcessor(processorName);
     }
 
-    public void notifyProcessorStarted(String processorName) {
-        EventProcessorStarted.Builder message = EventProcessorStarted.newBuilder().setProcessorName(processorName);
-        PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
-                                                                           .setEventProcessorStarted(message)
-                                                                           .build();
-        platformConnectionManager.send(instruction);
-    }
 
-    public void notifyProcessorPaused(String processorName) {
-        EventProcessorPaused.Builder message = EventProcessorPaused.newBuilder().setProcessorName(processorName);
-        PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
-                                                                           .setEventProcessorPaused(message)
-                                                                           .build();
-        platformConnectionManager.send(instruction);
-    }
 
 
 

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
@@ -1,7 +1,6 @@
-package io.axoniq.axonhub.client.event;
+package io.axoniq.axonhub.client.processor;
 
 import io.axoniq.axonhub.client.PlatformConnectionManager;
-import io.axoniq.axonhub.client.event.axon.EventProcessorController;
 import io.axoniq.platform.grpc.EventProcessorPaused;
 import io.axoniq.platform.grpc.EventProcessorStarted;
 import io.axoniq.platform.grpc.PauseEventProcessor;
@@ -26,7 +25,9 @@ public class EventProcessorControlService {
                                         EventProcessorController eventProcessorController) {
         this.platformConnectionManager = platformConnectionManager;
         this.eventProcessorController = eventProcessorController;
+    }
 
+    public void init(){
         this.platformConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
         this.platformConnectionManager.onOutboundInstruction(STAR_EVENT_PROCESSOR, this::startProcessor);
 
@@ -34,19 +35,19 @@ public class EventProcessorControlService {
         this.eventProcessorController.onStart(this::notifyProcessorStarted);
     }
 
-    public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction){
+    public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
         PauseEventProcessor pauseEventProcessor = platformOutboundInstruction.getPauseEventProcessor();
         String processorName = pauseEventProcessor.getProcessorName();
         eventProcessorController.pauseProcessor(processorName);
     }
 
-    public void startProcessor(PlatformOutboundInstruction platformOutboundInstruction){
+    public void startProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
         StartEventProcessor starEventProcessor = platformOutboundInstruction.getStarEventProcessor();
         String processorName = starEventProcessor.getProcessorName();
         eventProcessorController.startProcessor(processorName);
     }
 
-    public void notifyProcessorStarted(String processorName){
+    public void notifyProcessorStarted(String processorName) {
         EventProcessorStarted.Builder message = EventProcessorStarted.newBuilder().setProcessorName(processorName);
         PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
                                                                            .setEventProcessorStarted(message)
@@ -54,13 +55,14 @@ public class EventProcessorControlService {
         platformConnectionManager.send(instruction);
     }
 
-    public void notifyProcessorPaused(String processorName){
+    public void notifyProcessorPaused(String processorName) {
         EventProcessorPaused.Builder message = EventProcessorPaused.newBuilder().setProcessorName(processorName);
         PlatformInboundInstruction instruction = PlatformInboundInstruction.newBuilder()
                                                                            .setEventProcessorPaused(message)
                                                                            .build();
         platformConnectionManager.send(instruction);
     }
+
 
 
 }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorControlService.java
@@ -26,7 +26,7 @@ public class EventProcessorControlService {
         this.eventProcessorController = eventProcessorController;
     }
 
-    public void init(){
+    public void start(){
         this.platformConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
         this.platformConnectionManager.onOutboundInstruction(START_EVENT_PROCESSOR, this::startProcessor);
     }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorController.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/EventProcessorController.java
@@ -1,4 +1,4 @@
-package io.axoniq.axonhub.client.event.axon;
+package io.axoniq.axonhub.client.processor;
 
 import org.axonframework.config.EventHandlingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
@@ -30,7 +30,6 @@ public class EventProcessorController {
     }
 
     public void pauseProcessor(String processor){
-        //TODO check if it is intended only for tracking processor (pause method instead of shutDown)
         getEventProcessor(processor).shutDown();
         this.pauseHandlers.forEach(consumer -> consumer.accept(processor));
     }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -39,7 +39,7 @@ public class GrpcEventProcessorInfoSource implements AxonHubEventProcessorInfoSo
             return new TrackingEventProcessorInfoMessage((TrackingEventProcessor) processor);
         if (processor instanceof SubscribingEventProcessor)
             return new SubscribingEventProcessorInfoMessage((SubscribingEventProcessor) processor);
-        return null;
+        throw new RuntimeException("Unknown instance of Event Processor detected.");
     }
 
 }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -34,7 +34,6 @@ public class GrpcEventProcessorInfoSource implements AxonHubEventProcessorInfoSo
         });
     }
 
-    //TODO Review
     private PlatformInboundMessage messageFor(EventProcessor processor){
         if (processor instanceof TrackingEventProcessor)
             return new TrackingEventProcessorInfoMessage((TrackingEventProcessor) processor);

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -1,0 +1,47 @@
+package io.axoniq.axonhub.client.processor.grpc;
+
+import io.axoniq.axonhub.client.PlatformConnectionManager;
+import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource;
+import org.axonframework.config.EventHandlingConfiguration;
+import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.SubscribingEventProcessor;
+import org.axonframework.eventhandling.TrackingEventProcessor;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+
+import java.util.List;
+
+/**
+ * Created by Sara Pellegrini on 15/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class GrpcEventProcessorInfoSource implements AxonHubEventProcessorInfoSource {
+
+    private final EventHandlingConfiguration eventHandlingConfiguration;
+
+    private final PlatformConnectionManager platformConnectionManager;
+
+    public GrpcEventProcessorInfoSource(EventHandlingConfiguration eventHandlingConfiguration,
+                                        PlatformConnectionManager platformConnectionManager) {
+        this.eventHandlingConfiguration = eventHandlingConfiguration;
+        this.platformConnectionManager = platformConnectionManager;
+    }
+
+    @Override
+    public void notifyInformation() {
+        List<EventProcessor> processors = eventHandlingConfiguration.getProcessors();
+        processors.forEach(processor -> {
+            PlatformInboundMessage message = messageFor(processor);
+            platformConnectionManager.send(message.instruction());
+        });
+    }
+
+    //TODO Review
+    private PlatformInboundMessage messageFor(EventProcessor processor){
+        if (processor instanceof TrackingEventProcessor)
+            return new TrackingEventProcessorInfoMessage((TrackingEventProcessor) processor);
+        if (processor instanceof SubscribingEventProcessor)
+            return new SubscribingEventProcessorInfoMessage((SubscribingEventProcessor) processor);
+        return null;
+    }
+
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -6,7 +6,6 @@ import org.axonframework.config.EventHandlingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.axonframework.eventhandling.tokenstore.TokenStore;
 
 import java.util.List;
 

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/PlatformInboundMessage.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/PlatformInboundMessage.java
@@ -1,0 +1,13 @@
+package io.axoniq.axonhub.client.processor.grpc;
+
+import io.axoniq.platform.grpc.PlatformInboundInstruction;
+
+/**
+ * Created by Sara Pellegrini on 15/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public interface PlatformInboundMessage {
+
+    PlatformInboundInstruction instruction();
+
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/SubscribingEventProcessorInfoMessage.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/SubscribingEventProcessorInfoMessage.java
@@ -1,0 +1,30 @@
+package io.axoniq.axonhub.client.processor.grpc;
+
+import io.axoniq.platform.grpc.EventProcessorInfo;
+import io.axoniq.platform.grpc.PlatformInboundInstruction;
+import org.axonframework.eventhandling.SubscribingEventProcessor;
+
+/**
+ * Created by Sara Pellegrini on 15/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class SubscribingEventProcessorInfoMessage implements PlatformInboundMessage {
+
+    private final SubscribingEventProcessor processor;
+
+    public SubscribingEventProcessorInfoMessage(SubscribingEventProcessor processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    public PlatformInboundInstruction instruction() {
+        EventProcessorInfo msg = EventProcessorInfo.newBuilder()
+                                                   .setProcessorName(processor.getName())
+                                                   .setMode("Subscribing")
+                                                   .build();
+        return PlatformInboundInstruction
+                .newBuilder()
+                .setEventProcessorInfo(msg)
+                .build();
+    }
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/TrackingEventProcessorInfoMessage.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/TrackingEventProcessorInfoMessage.java
@@ -1,0 +1,57 @@
+package io.axoniq.axonhub.client.processor.grpc;
+
+import io.axoniq.platform.grpc.EventProcessorInfo;
+import io.axoniq.platform.grpc.EventProcessorInfo.EventTrackerInfo;
+import io.axoniq.platform.grpc.PlatformInboundInstruction;
+import org.axonframework.eventhandling.EventTrackerStatus;
+import org.axonframework.eventhandling.TrackingEventProcessor;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Created by Sara Pellegrini on 15/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class TrackingEventProcessorInfoMessage implements PlatformInboundMessage {
+
+    private final TrackingEventProcessor processor;
+
+    public TrackingEventProcessorInfoMessage(TrackingEventProcessor processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    public PlatformInboundInstruction instruction() {
+        Map<Integer, EventTrackerStatus> statusMap = processor.processingStatus();
+
+
+        List<EventTrackerInfo> trackers = statusMap
+                .entrySet()
+                .stream()
+                .map(e -> EventTrackerInfo.newBuilder()
+                                          .setSegmentId(e.getKey())
+                                          .setCaughtUp(e.getValue().isCaughtUp())
+                                          .setReplaying(e.getValue().isReplaying())
+                                          .setOnePartOf(e.getValue().getSegment().getMask()+1)
+
+                     .build())
+                .collect(toList());
+
+        EventProcessorInfo msg = EventProcessorInfo.newBuilder()
+                                                   .setProcessorName(processor.getName())
+                                                   .setMode("Tracking")
+                                                   .setActiveThreads(processor.activeProcessorThreads())
+                                                   .setRunning(processor.isRunning())
+                                                   .setError(processor.isError())
+                                                   .addAllEventTrackersInfo(trackers)
+                                                   .build();
+        return PlatformInboundInstruction
+                .newBuilder()
+                .setEventProcessorInfo(msg)
+                .build();
+    }
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/TrackingEventProcessorInfoMessage.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/grpc/TrackingEventProcessorInfoMessage.java
@@ -5,7 +5,6 @@ import io.axoniq.platform.grpc.EventProcessorInfo.EventTrackerInfo;
 import io.axoniq.platform.grpc.PlatformInboundInstruction;
 import org.axonframework.eventhandling.EventTrackerStatus;
 import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.axonframework.eventhandling.tokenstore.TokenStore;
 
 import java.util.List;
 import java.util.Map;

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
@@ -37,6 +37,10 @@ public class ScheduledEventProcessorInfoSource implements AxonHubEventProcessorI
         delegate.notifyInformation();
     }
 
+    public void shutdown(){
+        scheduler.shutdown();
+    }
+
 
 
 }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
@@ -1,0 +1,37 @@
+package io.axoniq.axonhub.client.processor.schedule;
+
+import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by Sara Pellegrini on 15/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class ScheduledEventProcessorInfoSource implements AxonHubEventProcessorInfoSource {
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    private final int schedulingPeriod;
+
+    private final AxonHubEventProcessorInfoSource delegate;
+
+    public ScheduledEventProcessorInfoSource(
+            int schedulingPeriod, AxonHubEventProcessorInfoSource delegate) {
+        this.schedulingPeriod = schedulingPeriod;
+        this.delegate = delegate;
+    }
+
+    public void start(){
+        scheduler.scheduleAtFixedRate(this::notifyInformation, 5,schedulingPeriod, TimeUnit.SECONDS);
+    }
+
+    public void notifyInformation(){
+        delegate.notifyInformation();
+    }
+
+
+
+}

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSource.java
@@ -14,18 +14,23 @@ public class ScheduledEventProcessorInfoSource implements AxonHubEventProcessorI
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
+    private final int initialDelay;
+
     private final int schedulingPeriod;
 
     private final AxonHubEventProcessorInfoSource delegate;
 
     public ScheduledEventProcessorInfoSource(
-            int schedulingPeriod, AxonHubEventProcessorInfoSource delegate) {
+            int initialDelay,
+            int schedulingPeriod,
+            AxonHubEventProcessorInfoSource delegate) {
+        this.initialDelay = initialDelay;
         this.schedulingPeriod = schedulingPeriod;
         this.delegate = delegate;
     }
 
     public void start(){
-        scheduler.scheduleAtFixedRate(this::notifyInformation, 5,schedulingPeriod, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(this::notifyInformation, initialDelay,schedulingPeriod, TimeUnit.MILLISECONDS);
     }
 
     public void notifyInformation(){

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/AxonHubQueryBus.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/AxonHubQueryBus.java
@@ -32,12 +32,15 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
+import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryMessage;
+import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.IntStream;
@@ -84,14 +87,16 @@ public class AxonHubQueryBus implements QueryBus {
 
 
     @Override
-    public <R> Registration subscribe(String queryName, Class<R> responseType, MessageHandler<? super QueryMessage<?, R>> handler) {
+    public <R> Registration subscribe(String queryName, Type responseType,
+                                      MessageHandler<? super QueryMessage<?, R>> handler) {
         return new AxonHubRegistration(queryProvider.subscribe(queryName, responseType, configuration.getComponentName(), handler),
-                () -> queryProvider.unsubscribe(queryName, responseType, configuration.getComponentName()));
+                                       () -> queryProvider.unsubscribe(queryName, responseType, configuration.getComponentName()));
+
     }
 
     @Override
-    public <Q, R> CompletableFuture<R> query(QueryMessage<Q, R> queryMessage) {
-        CompletableFuture<R> completableFuture = new CompletableFuture<>();
+    public <Q, R> CompletableFuture<QueryResponseMessage<R>> query(QueryMessage<Q, R> queryMessage) {
+        CompletableFuture<QueryResponseMessage<R>> completableFuture = new CompletableFuture<>();
         QueryServiceGrpc.newStub(platformConnectionManager.getChannel())
                 .withInterceptors(interceptors)
                 .query(serializer.serializeRequest(queryMessage, 1,
@@ -101,7 +106,7 @@ public class AxonHubQueryBus implements QueryBus {
                     @SuppressWarnings("unchecked")
                     public void onNext(QueryResponse commandResponse) {
                         logger.debug("Received response: {}", commandResponse);
-                        completableFuture.complete((R)serializer.deserializeResponse(commandResponse));
+                        completableFuture.complete(new GenericQueryResponseMessage<>((R)serializer.deserializeResponse(commandResponse)));
                     }
 
                     @Override
@@ -121,8 +126,8 @@ public class AxonHubQueryBus implements QueryBus {
     }
 
     @Override
-    public <Q, R> Stream<R> queryAll(QueryMessage<Q, R> queryMessage, long timeout, TimeUnit timeUnit) {
-        QueueBackedSpliterator<R> resultSpliterator = new QueueBackedSpliterator<>(timeout, timeUnit);
+    public <Q, R> Stream<QueryResponseMessage<R>> scatterGather(QueryMessage<Q, R> queryMessage, long timeout, TimeUnit timeUnit) {
+        QueueBackedSpliterator<QueryResponseMessage<R>> resultSpliterator = new QueueBackedSpliterator<>(timeout, timeUnit);
         QueryServiceGrpc.newStub(platformConnectionManager.getChannel())
                 .withInterceptors(interceptors)
                 .withDeadlineAfter(timeout, timeUnit)
@@ -133,7 +138,7 @@ public class AxonHubQueryBus implements QueryBus {
                         @SuppressWarnings("unchecked")
                         public void onNext(QueryResponse commandResponse) {
                             logger.debug("Received response: {}", commandResponse);
-                            resultSpliterator.put((R)serializer.deserializeResponse(commandResponse));
+                            resultSpliterator.put(new GenericQueryResponseMessage(serializer.deserializeResponse(commandResponse)));
                         }
 
                         @Override
@@ -190,7 +195,7 @@ public class AxonHubQueryBus implements QueryBus {
             String messageId = query.getMessageIdentifier();
             try {
                 //noinspection unchecked
-                localSegment.queryAll(serializer.deserializeRequest(query), 0, TimeUnit.SECONDS)
+                localSegment.scatterGather(serializer.deserializeRequest(query), 0, TimeUnit.SECONDS)
                         .forEach(response -> outboundStreamObserver.onNext(
                                         QueryProviderOutbound.newBuilder()
                                         .setQueryResponse(serializer.serializeResponse(response, messageId))
@@ -211,8 +216,8 @@ public class AxonHubQueryBus implements QueryBus {
         }
 
         @SuppressWarnings("unchecked")
-        public <R> Registration subscribe(String queryName, Class<R> responseType, String componentName, MessageHandler<? super QueryMessage<?, R>> handler) {
-            Set registrations = subscribedQueries.computeIfAbsent( new QueryDefinition(queryName, responseType.getName(), componentName), k -> new CopyOnWriteArraySet<>());
+        public <R> Registration subscribe(String queryName, Type responseType, String componentName, MessageHandler<? super QueryMessage<?, R>> handler) {
+            Set registrations = subscribedQueries.computeIfAbsent( new QueryDefinition(queryName, responseType.getTypeName(), componentName), k -> new CopyOnWriteArraySet<>());
             registrations.add( handler);
 
             try {
@@ -222,7 +227,7 @@ public class AxonHubQueryBus implements QueryBus {
                                 .setClientName(configuration.getClientName())
                                 .setComponentName(componentName)
                                 .setQuery(queryName)
-                                .setResultName(responseType.getName())
+                                .setResultName(responseType.getTypeName())
                                 .setNrOfHandlers(registrations.size())
                                 .build())
                         .build());
@@ -268,8 +273,8 @@ public class AxonHubQueryBus implements QueryBus {
             return outboundStreamObserver;
         }
 
-        public void unsubscribe(String queryName, Class responseType, String componentName) {
-            QueryDefinition queryDefinition = new QueryDefinition(queryName, responseType.getName(), componentName);
+        public void unsubscribe(String queryName, Type responseType, String componentName) {
+            QueryDefinition queryDefinition = new QueryDefinition(queryName, responseType.getTypeName(), componentName);
             subscribedQueries.remove(queryDefinition);
             try {
                 getSubscriberObserver().onNext(QueryProviderOutbound.newBuilder().setUnsubscribe(

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/GrpcBackedQueryMessage.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/GrpcBackedQueryMessage.java
@@ -19,6 +19,8 @@ import io.axoniq.platform.MetaDataValue;
 import io.axoniq.axonhub.QueryRequest;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.QueryMessage;
+import org.axonframework.queryhandling.responsetypes.InstanceResponseType;
+import org.axonframework.queryhandling.responsetypes.ResponseType;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
@@ -48,12 +50,14 @@ public class GrpcBackedQueryMessage<T, R> implements QueryMessage<T, R> {
     }
 
     @Override
-    public Class<R> getResponseType() {
+    public ResponseType<R> getResponseType() {
 
         try {
-            if( "int".equals(query.getResultName())) return (Class<R>) int.class;
-            if( "float".equals(query.getResultName())) return (Class<R>) float.class;
-            return (Class<R>) Class.forName(query.getResultName());
+            Class<R> klass;
+            if( "int".equals(query.getResultName())) klass = (Class<R>) int.class;
+            else if( "float".equals(query.getResultName())) klass = (Class<R>) float.class;
+            else klass = (Class<R>) Class.forName(query.getResultName());
+            return new InstanceResponseType<>(klass);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException("Illegal response type", e);
         }

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/QuerySerializer.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/query/QuerySerializer.java
@@ -60,7 +60,7 @@ public class QuerySerializer extends MessagePlatformSerializer {
                 .setTimestamp(System.currentTimeMillis())
                 .setMessageIdentifier(UUID.randomUUID().toString())
                 .setQuery(queryMessage.getQueryName())
-                .setResultName(queryMessage.getResponseType().getName())
+                .setResultName(queryMessage.getResponseType().toString())
                 .setPayload(
                         io.axoniq.platform.SerializedObject.newBuilder()
                                 .setData(ByteString.copyFrom(serializedPayload.getData()))

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/FakeAxonHubEventProcessorInfoSource.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/FakeAxonHubEventProcessorInfoSource.java
@@ -1,0 +1,19 @@
+package io.axoniq.axonhub.client.processor;
+
+/**
+ * Created by Sara Pellegrini on 30/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class FakeAxonHubEventProcessorInfoSource implements AxonHubEventProcessorInfoSource {
+
+    private int notifyCalls;
+
+    @Override
+    public void notifyInformation() {
+        notifyCalls++;
+    }
+
+    public int notifyCalls() {
+        return notifyCalls;
+    }
+}

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
@@ -1,0 +1,27 @@
+package io.axoniq.axonhub.client.processor.schedule;
+
+import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource;
+import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource.Fake;
+import org.junit.*;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Sara Pellegrini on 23/03/2018.
+ * sara.pellegrini@gmail.com
+ */
+public class ScheduledEventProcessorInfoSourceTest {
+
+    @Test
+    public void notifyInformation() throws InterruptedException {
+        Fake delegate = new Fake();
+        ScheduledEventProcessorInfoSource scheduled = new ScheduledEventProcessorInfoSource(4,delegate);
+        scheduled.start();
+        TimeUnit.SECONDS.sleep(10);
+        assertEquals(2, delegate.notifyCalls());
+    }
+
+
+}

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
@@ -1,6 +1,5 @@
 package io.axoniq.axonhub.client.processor.schedule;
 
-import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource;
 import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource.Fake;
 import org.junit.*;
 

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
@@ -16,9 +16,9 @@ public class ScheduledEventProcessorInfoSourceTest {
     @Test
     public void notifyInformation() throws InterruptedException {
         Fake delegate = new Fake();
-        ScheduledEventProcessorInfoSource scheduled = new ScheduledEventProcessorInfoSource(4,delegate);
+        ScheduledEventProcessorInfoSource scheduled = new ScheduledEventProcessorInfoSource(50,30,delegate);
         scheduled.start();
-        TimeUnit.SECONDS.sleep(10);
+        TimeUnit.MILLISECONDS.sleep(90);
         assertEquals(2, delegate.notifyCalls());
     }
 

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
@@ -1,6 +1,6 @@
 package io.axoniq.axonhub.client.processor.schedule;
 
-import io.axoniq.axonhub.client.processor.AxonHubEventProcessorInfoSource.Fake;
+import io.axoniq.axonhub.client.processor.FakeAxonHubEventProcessorInfoSource;
 import org.junit.*;
 
 import java.util.concurrent.TimeUnit;
@@ -15,7 +15,7 @@ public class ScheduledEventProcessorInfoSourceTest {
 
     @Test
     public void notifyInformation() throws InterruptedException {
-        Fake delegate = new Fake();
+        FakeAxonHubEventProcessorInfoSource delegate = new FakeAxonHubEventProcessorInfoSource();
         ScheduledEventProcessorInfoSource scheduled = new ScheduledEventProcessorInfoSource(50,30,delegate);
         scheduled.start();
         TimeUnit.MILLISECONDS.sleep(90);

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/query/AxonHubQueryBusTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/query/AxonHubQueryBusTest.java
@@ -28,24 +28,22 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.SimpleQueryBus;
+import org.axonframework.queryhandling.responsetypes.InstanceResponseType;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * Author: marc
  */
 public class AxonHubQueryBusTest {
+
     private AxonHubQueryBus queryBus;
     private DummyMessagePlatformServer dummyMessagePlatformServer;
     private XStreamSerializer ser;
@@ -87,9 +85,9 @@ public class AxonHubQueryBusTest {
 
     @Test
     public void query() throws Exception {
-        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World", String.class);
+        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World", new InstanceResponseType(String.class));
 
-        assertEquals("test", queryBus.query(queryMessage).get());
+        assertEquals("test", queryBus.query(queryMessage).get().getPayload());
     }
 
     @Test
@@ -131,24 +129,23 @@ public class AxonHubQueryBusTest {
         inboundStreamObserverRef.get().onNext(inboundMessage);
 
         response.close();
-
     }
 
     @Test
-    public void queryAll() throws Exception {
-        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World", String.class)
+    public void scatterGather() throws Exception {
+        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World",
+                                                                              new InstanceResponseType(String.class))
                 .andMetaData(MetaData.with("repeat", 10).and("interval", 10));
 
-        assertEquals(10, queryBus.queryAll(queryMessage, 2, TimeUnit.SECONDS).count());
+        assertEquals(10, queryBus.scatterGather(queryMessage, 12, TimeUnit.SECONDS).count());
     }
 
     @Test
-    public void queryAllTimeout() throws Exception {
-        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World", String.class)
+    public void scatterGatherTimeout() throws Exception {
+        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>("Hello, World",
+                                                                              new InstanceResponseType(String.class))
                 .andMetaData(MetaData.with("repeat", 10).and("interval", 100));
 
-        assertTrue(8 > queryBus.queryAll(queryMessage, 550, TimeUnit.MILLISECONDS).count());
+        assertTrue(8 > queryBus.scatterGather(queryMessage, 550, TimeUnit.MILLISECONDS).count());
     }
-
-
 }

--- a/axonhub-grpc-proto/src/main/proto/platform_api.proto
+++ b/axonhub-grpc-proto/src/main/proto/platform_api.proto
@@ -14,6 +14,9 @@ service PlatformService {
 message PlatformInboundInstruction {
     oneof request {
         ClientIdentification register = 1;
+        EventProcessorInfo processor_notification = 2;
+        EventProcessorPaused event_processor_paused = 3;
+        EventProcessorStarted event_processor_started = 4;
     }
 }
 
@@ -22,6 +25,8 @@ message PlatformOutboundInstruction {
         NodeInfo node_notification = 1;
         RequestReconnect request_reconnect = 3;
         RequestReleaseTracker request_release_tracker = 4;
+        PauseEventProcessor pause_event_processor = 5;
+        StartEventProcessor star_event_processor = 6;
     }
 }
 
@@ -48,3 +53,23 @@ message ClientIdentification {
     string component_name = 2;
 }
 
+message EventProcessorInfo {
+    string processor_name = 1;
+    string mode = 2;
+}
+
+message PauseEventProcessor {
+    string processor_name = 1;
+}
+
+message StartEventProcessor {
+    string processor_name = 1;
+}
+
+message EventProcessorStarted {
+    string processor_name = 1;
+}
+
+message EventProcessorPaused {
+    string processor_name = 1;
+}

--- a/axonhub-grpc-proto/src/main/proto/platform_api.proto
+++ b/axonhub-grpc-proto/src/main/proto/platform_api.proto
@@ -15,8 +15,6 @@ message PlatformInboundInstruction {
     oneof request {
         ClientIdentification register = 1;
         EventProcessorInfo event_processor_info = 2;
-        EventProcessorPaused event_processor_paused = 3;
-        EventProcessorStarted event_processor_started = 4;
     }
 }
 
@@ -79,10 +77,3 @@ message StartEventProcessor {
     string processor_name = 1;
 }
 
-message EventProcessorStarted {
-    string processor_name = 1;
-}
-
-message EventProcessorPaused {
-    string processor_name = 1;
-}

--- a/axonhub-grpc-proto/src/main/proto/platform_api.proto
+++ b/axonhub-grpc-proto/src/main/proto/platform_api.proto
@@ -22,16 +22,12 @@ message PlatformOutboundInstruction {
     oneof request {
         NodeInfo node_notification = 1;
         RequestReconnect request_reconnect = 3;
-        RequestReleaseTracker request_release_tracker = 4;
-        PauseEventProcessor pause_event_processor = 5;
-        StartEventProcessor star_event_processor = 6;
+        PauseEventProcessor pause_event_processor = 4;
+        StartEventProcessor start_event_processor = 5;
     }
 }
 
 message RequestReconnect {
-}
-
-message RequestReleaseTracker {
 }
 
 message PlatformInfo {

--- a/axonhub-grpc-proto/src/main/proto/platform_api.proto
+++ b/axonhub-grpc-proto/src/main/proto/platform_api.proto
@@ -56,9 +56,7 @@ message EventProcessorInfo {
         int32 segment_id = 1;
         bool caught_up = 2;
         bool replaying = 3;
-        string token_type = 4;
-        string token_index = 5;
-        int32 one_part_of = 6;
+        int32 one_part_of = 4;
     }
 
     string processor_name = 1;

--- a/axonhub-grpc-proto/src/main/proto/platform_api.proto
+++ b/axonhub-grpc-proto/src/main/proto/platform_api.proto
@@ -14,7 +14,7 @@ service PlatformService {
 message PlatformInboundInstruction {
     oneof request {
         ClientIdentification register = 1;
-        EventProcessorInfo processor_notification = 2;
+        EventProcessorInfo event_processor_info = 2;
         EventProcessorPaused event_processor_paused = 3;
         EventProcessorStarted event_processor_started = 4;
     }
@@ -54,8 +54,21 @@ message ClientIdentification {
 }
 
 message EventProcessorInfo {
+    message EventTrackerInfo {
+        int32 segment_id = 1;
+        bool caught_up = 2;
+        bool replaying = 3;
+        string token_type = 4;
+        string token_index = 5;
+        int32 one_part_of = 6;
+    }
+
     string processor_name = 1;
     string mode = 2;
+    int32 activeThreads = 3;
+    bool running = 4;
+    bool error = 5;
+    repeated EventTrackerInfo event_trackers_info = 6;
 }
 
 message PauseEventProcessor {

--- a/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
+++ b/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.axoniq.axonhub.client.AxonHubConfiguration;
 import io.axoniq.axonhub.client.PlatformConnectionManager;
 import io.axoniq.axonhub.client.command.AxonHubCommandBus;
 import io.axoniq.axonhub.client.command.CommandPriorityCalculator;
+import io.axoniq.axonhub.client.event.axon.AxonHubEvenProcessorInfoConfiguration;
 import io.axoniq.axonhub.client.processor.EventProcessorController;
 import io.axoniq.axonhub.client.processor.EventProcessorControlService;
 import io.axoniq.axonhub.client.processor.grpc.GrpcEventProcessorInfoSource;
@@ -122,26 +123,33 @@ public class MessagingAutoConfiguration implements ApplicationContextAware {
     }
 
     @Bean
-    public EventProcessorController eventProcessorController(EventHandlingConfiguration configuration){
-        return new EventProcessorController(configuration);
+    public AxonHubEvenProcessorInfoConfiguration processorInfoConfiguration(EventHandlingConfiguration eventHandlingConfiguration,
+                                                                            PlatformConnectionManager connectionManager,
+                                                                            AxonHubConfiguration configuration){
+        return new AxonHubEvenProcessorInfoConfiguration(eventHandlingConfiguration,connectionManager, configuration);
     }
 
-    @Bean(initMethod = "init")
-    public EventProcessorControlService eventProcessorService(PlatformConnectionManager platformConnectionManager,
-                                                              EventProcessorController eventProcessorController){
-        return new EventProcessorControlService(platformConnectionManager, eventProcessorController);
-    }
+//    @Bean
+//    public EventProcessorController eventProcessorController(EventHandlingConfiguration configuration){
+//        return new EventProcessorController(configuration);
+//    }
 
-    @Bean(initMethod = "start")
-    public ScheduledEventProcessorInfoSource eventProcessorInfoSource(
-            AxonHubConfiguration axonHubConfiguration,
-            PlatformConnectionManager connectionManager,
-            EventHandlingConfiguration configuration){
-        GrpcEventProcessorInfoSource grpcSource = new GrpcEventProcessorInfoSource(configuration, connectionManager);
-        return new ScheduledEventProcessorInfoSource(
-                axonHubConfiguration.getProcessorsNotificationInitialDelay(),
-                axonHubConfiguration.getProcessorsNotificationRate(),
-                grpcSource);
-    }
+//    @Bean(initMethod = "init")
+//    public EventProcessorControlService eventProcessorService(PlatformConnectionManager platformConnectionManager,
+//                                                              EventProcessorController eventProcessorController){
+//        return new EventProcessorControlService(platformConnectionManager, eventProcessorController);
+//    }
+//
+//    @Bean(initMethod = "start")
+//    public ScheduledEventProcessorInfoSource eventProcessorInfoSource(
+//            AxonHubConfiguration axonHubConfiguration,
+//            PlatformConnectionManager connectionManager,
+//            EventHandlingConfiguration configuration){
+//        GrpcEventProcessorInfoSource grpcSource = new GrpcEventProcessorInfoSource(configuration, connectionManager);
+//        return new ScheduledEventProcessorInfoSource(
+//                axonHubConfiguration.getProcessorsNotificationInitialDelay(),
+//                axonHubConfiguration.getProcessorsNotificationRate(),
+//                grpcSource);
+//    }
 }
 

--- a/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
+++ b/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
@@ -20,6 +20,8 @@ import io.axoniq.axonhub.client.AxonHubConfiguration;
 import io.axoniq.axonhub.client.PlatformConnectionManager;
 import io.axoniq.axonhub.client.command.AxonHubCommandBus;
 import io.axoniq.axonhub.client.command.CommandPriorityCalculator;
+import io.axoniq.axonhub.client.event.axon.EventProcessorController;
+import io.axoniq.axonhub.client.event.EventProcessorControlService;
 import io.axoniq.axonhub.client.query.AxonHubQueryBus;
 import io.axoniq.axonhub.client.query.QueryPriorityCalculator;
 import org.axonframework.boot.autoconfig.AxonAutoConfiguration;
@@ -27,6 +29,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.config.EventHandlingConfiguration;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryBus;
@@ -115,5 +118,17 @@ public class MessagingAutoConfiguration implements ApplicationContextAware {
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }
+
+    @Bean
+    public EventProcessorController eventProcessorController(EventHandlingConfiguration configuration){
+        return new EventProcessorController(configuration);
+    }
+
+    @Bean
+    public EventProcessorControlService eventProcessorService(PlatformConnectionManager platformConnectionManager,
+                                                              EventProcessorController eventProcessorController){
+        return new EventProcessorControlService(platformConnectionManager, eventProcessorController);
+    }
+
 }
 

--- a/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
+++ b/axonhub-spring-boot-autoconfigure/src/main/java/io/axoniq/axonhub/client/boot/MessagingAutoConfiguration.java
@@ -138,7 +138,10 @@ public class MessagingAutoConfiguration implements ApplicationContextAware {
             PlatformConnectionManager connectionManager,
             EventHandlingConfiguration configuration){
         GrpcEventProcessorInfoSource grpcSource = new GrpcEventProcessorInfoSource(configuration, connectionManager);
-        return new ScheduledEventProcessorInfoSource(axonHubConfiguration.getProcessorsNotificationPeriod(), grpcSource);
+        return new ScheduledEventProcessorInfoSource(
+                axonHubConfiguration.getProcessorsNotificationInitialDelay(),
+                axonHubConfiguration.getProcessorsNotificationRate(),
+                grpcSource);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <axon.version>3.1.1</axon.version>
+        <axon.version>3.2</axon.version>
         <swagger.version>2.7.0</swagger.version>
         <slf4j.version>1.7.25</slf4j.version>
         <jackson.version>2.9.0</jackson.version>


### PR DESCRIPTION
Please verifies whether the changes to the queryBus are consistent (needed after the upgrade to Axon Framework 3.2)

Note:
ScheduledEventProcessorInfoSource intentionally created to stress the need of this scheduling if you don't use Spring Auto Configuration. 
alternatively, I can replace this class with:
    @Scheduled( initialDelayString = "${axoniq.axon....}",  fixedRateString = "${axoniq.axonhu...}")
    public void eventProcessorInfoSource(GrpcEventProcessorInfoSource eventProcessorInfoSource){
        eventProcessorInfoSource.notifyInformation();
    }
