### PR TITLE
Do a re-subscription on stream errors in a unified way.

### DIFF
--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/AxonHubConfiguration.java
@@ -108,7 +108,7 @@ public class AxonHubConfiguration {
     /**
      * Interval (in ms) for keep alive requests, 0 is keep-alive disabled
      */
-    private long keepAliveTime = 0;
+    private long keepAliveTime = 1000;
     /**
      * Interval at which the server is requested to send a heartbeat on open event streams, when no
      * events are sent.

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/PlatformConnectionManager.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/PlatformConnectionManager.java
@@ -194,7 +194,7 @@ public class PlatformConnectionManager {
 
                     @Override
                     public void onError(Throwable throwable) {
-                        logger.debug("Lost instruction stream from {} - {}", name, throwable.getMessage());
+                        logger.warn("Lost instruction stream from {} - {}", name, throwable.getMessage());
                         disconnectListeners.forEach(Runnable::run);
                         if( throwable instanceof StatusRuntimeException) {
                             StatusRuntimeException sre = (StatusRuntimeException)throwable;

--- a/axonhub-client/src/main/java/io/axoniq/axonhub/client/util/ResubscribableStreamObserver.java
+++ b/axonhub-client/src/main/java/io/axoniq/axonhub/client/util/ResubscribableStreamObserver.java
@@ -1,0 +1,63 @@
+package io.axoniq.axonhub.client.util;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.netty.util.internal.OutOfDirectMemoryError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
+
+/**
+ * Wrapper around {@link StreamObserver} that re-subscribes on error received (if other side is still available).
+ *
+ * @author Milan Savic
+ * @since 1.1.4
+ */
+public class ResubscribableStreamObserver<V> implements StreamObserver<V> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResubscribableStreamObserver.class);
+
+    private final StreamObserver<V> delegate;
+    private final Consumer<Throwable> resubscribe;
+
+    /**
+     * Creates the Re-subscribable Stream Observer.
+     *
+     * @param delegate    the StreamObserver to delegate calls
+     * @param resubscribe the re-subscription consumer - should implement the actual re-subscription
+     */
+    public ResubscribableStreamObserver(StreamObserver<V> delegate,
+                                        Consumer<Throwable> resubscribe) {
+        this.delegate = delegate;
+        this.resubscribe = resubscribe;
+    }
+
+    @Override
+    public void onNext(V value) {
+        try {
+            delegate.onNext(value);
+        } catch (Exception | OutOfDirectMemoryError e) {
+            onError(e);
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        logger.warn("A problem occurred in the stream.", t);
+        delegate.onError(t);
+        if (t instanceof StatusRuntimeException
+                && ((StatusRuntimeException) t).getStatus().getCode()
+                                               .equals(Status.UNAVAILABLE.getCode())) {
+            return;
+        }
+        logger.info("Resubscribing.");
+        resubscribe.accept(t);
+    }
+
+    @Override
+    public void onCompleted() {
+        delegate.onCompleted();
+    }
+}

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/command/AxonHubCommandBusTest.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/command/AxonHubCommandBusTest.java
@@ -37,9 +37,11 @@ import org.junit.Test;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.axoniq.axonhub.client.common.AssertUtils.assertWithin;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -127,11 +129,11 @@ public class AxonHubCommandBusTest {
     @Test
     public void subscribe() throws Exception {
         Registration registration = testSubject.subscribe(String.class.getName(), c -> "Done");
-        Thread.sleep(30);
-        assertEquals(1, dummyMessagePlatformServer.subscriptions(String.class.getName()).size());
+        assertWithin(100, TimeUnit.MILLISECONDS, () ->
+                assertNotNull(dummyMessagePlatformServer.subscriptions(String.class.getName())));
         registration.cancel();
-        Thread.sleep(30);
-        assertEquals(0, dummyMessagePlatformServer.subscriptions(String.class.getName()).size());
+        assertWithin(100, TimeUnit.MILLISECONDS, () ->
+                assertNull(dummyMessagePlatformServer.subscriptions(String.class.getName())));
     }
 
     @Test
@@ -175,13 +177,13 @@ public class AxonHubCommandBusTest {
     @Test
     public void resubscribe() throws Exception {
         testSubject.subscribe(String.class.getName(), c -> "Done");
-        Thread.sleep(30);
-        assertEquals(1, dummyMessagePlatformServer.subscriptions(String.class.getName()).size());
+        assertWithin(1, TimeUnit.SECONDS, () ->
+                assertNotNull(dummyMessagePlatformServer.subscriptions(String.class.getName())));
         dummyMessagePlatformServer.stop();
         assertNull(dummyMessagePlatformServer.subscriptions(String.class.getName()));
         dummyMessagePlatformServer.start();
-        Thread.sleep(3000);
-        assertEquals(1, dummyMessagePlatformServer.subscriptions(String.class.getName()).size());
+        assertWithin(5, TimeUnit.SECONDS, () ->
+                assertNotNull(dummyMessagePlatformServer.subscriptions(String.class.getName())));
     }
 
     @Test

--- a/axonhub-client/src/test/java/io/axoniq/axonhub/client/command/DummyMessagePlatformServer.java
+++ b/axonhub-client/src/test/java/io/axoniq/axonhub/client/command/DummyMessagePlatformServer.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public class DummyMessagePlatformServer {
     private final int port;
     private Server server;
-    private Map<String, Set<StreamObserver>> subscriptions = new HashMap<>();
+    private Map<String, StreamObserver> subscriptions = new HashMap<>();
 
     public DummyMessagePlatformServer(int port) {
         this.port = port;
@@ -62,7 +62,7 @@ public class DummyMessagePlatformServer {
         }
     }
 
-    public Set subscriptions(String query) {
+    public StreamObserver subscriptions(String query) {
         return subscriptions.get(query);
     }
 
@@ -75,17 +75,12 @@ public class DummyMessagePlatformServer {
                 public void onNext(CommandProviderOutbound queryProviderOutbound) {
                     switch(queryProviderOutbound.getRequestCase()) {
                         case SUBSCRIBE:
-                            subscriptions.computeIfAbsent(queryProviderOutbound.getSubscribe().getCommand(), k -> new HashSet<>()).add(responseObserver);
+                            subscriptions.put(queryProviderOutbound.getSubscribe().getCommand(), responseObserver);
                             break;
                         case UNSUBSCRIBE:
-                            Set<StreamObserver> connected = subscriptions.get(queryProviderOutbound.getUnsubscribe().getCommand());
-                            if( connected != null) connected.remove(responseObserver);
+                            subscriptions.remove(queryProviderOutbound.getUnsubscribe().getCommand(), responseObserver);
                             break;
-                        case FLOWCONTROL:
-                            break;
-                        case COMMANDRESPONSE:
-                            break;
-                        case REQUEST_NOT_SET:
+                        default:
                             break;
                     }
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,13 @@
             Please note that there are dependencies between the gRPC and Netty TcNative versions.
             gRPC is quite specific about the version of Netty TcNative, so check the dependencies on
             https://mvnrepository.com/artifact/io.grpc/grpc-netty/<grpcVersion>
+            https://github.com/grpc/grpc-java/blob/master/SECURITY.md
 
             - We use (in our default client artifact) a statically-linked version of Netty TcNative. This contains
               native libraries for BoringSSL (Google fork of OpenSSL).
         -->
-        <grpc.version>1.13.1</grpc.version>
-        <netty.tcnative.version>2.0.8.Final</netty.tcnative.version>
+        <grpc.version>1.19.0</grpc.version>
+        <netty.tcnative.version>2.0.20.Final</netty.tcnative.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Introduced a `ResubscribableStreamObserver` to do a resubscription when `onError` occurs and when `onNext` fails.